### PR TITLE
Changes GAV to org.bedework:bw-ical4j-cl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,17 +9,15 @@
 	</parent>
    -->
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>net.fortuna.ical4j</groupId>
-	<artifactId>ical4j</artifactId>
+	<groupId>org.bedework</groupId>
+	<artifactId>bw-ical4j-cl</artifactId>
 	<packaging>bundle</packaging>
-	<name>iCal4j</name>
+	<name>Bedework iCal4j</name>
   <!--
 	<version>1.0-SNAPSHOT</version> -->
-        <version>1.1-BW-SNAPSHOT</version>
-	<description>
-		A Java library for reading and writing iCalendar (*.ics) files
-	</description>
-	<url>http://ical4j.sourceforge.net</url>
+        <version>1.1.0-SNAPSHOT</version>
+	<description>A fork of iCal4j with customizations for Bedework.</description>
+	<url>https://github.com/Bedework/bw-ical4j-cl</url>
 
 	<properties>
 		<bedework.releases.repo.url>scp://dev.bedework.org/data/repository/maven/maven2</bedework.releases.repo.url>
@@ -27,8 +25,8 @@
 	</properties>
 
 	<issueManagement>
-		<system>SourceForge.net</system>
-		<url>https://sourceforge.net/tracker/?group_id=107024</url>
+		<system>Github</system>
+		<url>https://github.com/Bedework/bw-ical4j-cl/issues</url>
 	</issueManagement>
 	<inceptionYear>2004</inceptionYear>
 	<licenses>


### PR DESCRIPTION
This pull request is a start for issue #1. It also changes a few project fields and URLs to relate to the fork's home in github.

I explicitly haven't touched license or distributionManagement yet. I also noticed that the Ant build.xml contains some 'dist-y' 'maven-y' type things. Will we need to update those, or could we consider just removing Ant from the build process altogether? Does it do something unique that Maven doesn't do?